### PR TITLE
Fix missing angular build builder

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@angular/cli": "^17.0.0",
     "@angular/compiler-cli": "^17.0.0",
+    "@angular-devkit/build-angular": "^17.0.0",
     "typescript": "~5.2.2"
   }
 }


### PR DESCRIPTION
## Summary
- include `@angular-devkit/build-angular` in the frontend dev dependencies

## Testing
- `npm install` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_686294358da8832d8ead310e773d2593