### PR TITLE
Fix build instructions and upgrade Angular deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ npm run build
 
 The Angular build outputs static files to `dist/`.
 
+**Note for Windows users**: Webpack does not allow `!` characters in paths. If
+your project is located in a directory containing an exclamation mark, the build
+will fail with an `Invalid configuration object` error. Move the project to a
+path without `!` before running `npm run build`.
+
 ## Running Locally
 
 ### Backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,17 +7,18 @@
     "build": "ng build"
   },
   "dependencies": {
-    "@angular/common": "^17.0.0",
-    "@angular/compiler": "^17.0.0",
-    "@angular/core": "^17.0.0",
-    "@angular/platform-browser": "^17.0.0",
-    "@angular/platform-browser-dynamic": "^17.0.0",
-    "rxjs": "^7.8.0",
-    "zone.js": "^0.14.0"
+    "@angular/common": "^17.3.0",
+    "@angular/compiler": "^17.3.0",
+    "@angular/core": "^17.3.0",
+    "@angular/platform-browser": "^17.3.0",
+    "@angular/platform-browser-dynamic": "^17.3.0",
+    "rxjs": "^7.8.1",
+    "zone.js": "^0.14.2"
   },
   "devDependencies": {
-    "@angular/cli": "^17.0.0",
-    "@angular/compiler-cli": "^17.0.0",
-    "typescript": "~5.2.2"
+    "@angular/cli": "^17.3.0",
+    "@angular/compiler-cli": "^17.3.0",
+    "@angular-devkit/build-angular": "^17.3.0",
+    "typescript": "~5.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump Angular packages to latest patch versions
- document Windows path restriction for Angular builds

## Testing
- `npm install` *(fails: 403 Forbidden due to offline environment)*
- `npm run build` *(fails: ng not found because dependencies were not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686294358da8832d8ead310e773d2593