### PR TITLE
Update Angular dependencies to v20

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,18 +7,26 @@
     "build": "ng build"
   },
   "dependencies": {
-    "@angular/common": "^17.3.0",
-    "@angular/compiler": "^17.3.0",
-    "@angular/core": "^17.3.0",
-    "@angular/platform-browser": "^17.3.0",
-    "@angular/platform-browser-dynamic": "^17.3.0",
-    "rxjs": "^7.8.1",
-    "zone.js": "^0.14.2"
+    "@angular/common": "^20.0.0",
+    "@angular/compiler": "^20.0.0",
+    "@angular/core": "^20.0.0",
+    "@angular/forms": "^20.0.0",
+    "@angular/platform-browser": "^20.0.0",
+    "@angular/router": "^20.0.0",
+    "rxjs": "~7.8.0",
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@angular/cli": "^17.3.0",
-    "@angular/compiler-cli": "^17.3.0",
-    "@angular-devkit/build-angular": "^17.3.0",
-    "typescript": "~5.4.0"
+    "@angular/build": "^20.0.4",
+    "@angular/cli": "^20.0.4",
+    "@angular/compiler-cli": "^20.0.0",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.7.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.8.2"
   }
 }


### PR DESCRIPTION
## Summary
- upgrade Angular and tooling to v20

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6862a0b3910c832dbf8f32c9c5e69d6c